### PR TITLE
Correction of the order in which a raw exception is made. 

### DIFF
--- a/src/modbusException.cpp
+++ b/src/modbusException.cpp
@@ -54,8 +54,8 @@ std::vector<uint8_t> ModbusException::toRaw() const noexcept {
   std::vector<uint8_t> result(3);
 
   result[0] = _slaveId;
-  result[1] = static_cast<uint8_t>(_errorCode | 0b10000000);
-  result[2] = static_cast<uint8_t>(_functionCode);
+  result[1] = static_cast<uint8_t>(_functionCode | 0b10000000);
+  result[2] = static_cast<uint8_t>(_errorCode);
 
   return result;
 }


### PR DESCRIPTION
The error code was first added and or'ed with 0b10000000 and then the function code added. But it should be first the function code which should be or'ed with 0b10000000 and then the error code.